### PR TITLE
Replaced string with boolean where tested for dismissed alarms in check_alerts()

### DIFF
--- a/check_freenas.py
+++ b/check_freenas.py
@@ -100,7 +100,7 @@ class Startup(object):
         msg=''
         try:
             for alert in alerts:
-              if alert['dismissed'] == 'false':
+              if alert['dismissed'] == False:
                 if alert['level'] == 'CRIT':
                     crit = crit + 1
                     msg = msg + '- (C) ' + string.replace(alert['message'], '\n', '. ') + ' '


### PR DESCRIPTION
What we currently have (`'false'`) matches only a string, and not boolean which FreeNAS returns, so not if this ever really worked.